### PR TITLE
Change path to Gebco basemap preview image

### DIFF
--- a/prod-catalog.json
+++ b/prod-catalog.json
@@ -825,7 +825,7 @@
           "layers": "GEBCO_2019_Grid",
           "opacity": 1.0
         },
-        "image": "images/gebco.png"
+        "image": "https://terria-catalogs-public.storage.googleapis.com/pacificmap/images/gebco.png"
       }
     ]
   }


### PR DESCRIPTION
This is to fix https://github.com/TerriaJS/saas-catalogs-public/issues/279 : 

Image for pacificmap basemap is missing in dev/test/prod. The image needs to be transferred to this repo, and the URL updated in config.
![image](https://user-images.githubusercontent.com/7980991/208573115-88b825a7-7422-495e-aafe-c0b5240f0866.png)

This config was pointing to the old way of serving images as used in https://github.com/PacificCommunity/Terria-PacificMap
Updated the path to point to the cloud storage now used for most map config, at https://terria-catalogs-public.storage.googleapis.com/pacificmap/images/gebco.png

## Test

See it fixed here: http://ci.terria.io/main/#configUrl=https://terria-catalogs-public.storage.googleapis.com/pacificmap/map-config/dev.json